### PR TITLE
Title renderer

### DIFF
--- a/lib/simple_navigation.rb
+++ b/lib/simple_navigation.rb
@@ -24,7 +24,8 @@ module SimpleNavigation
   self.registered_renderers = {
     :list         => SimpleNavigation::Renderer::List,
     :links        => SimpleNavigation::Renderer::Links,
-    :breadcrumbs  => SimpleNavigation::Renderer::Breadcrumbs
+    :breadcrumbs  => SimpleNavigation::Renderer::Breadcrumbs,
+    :title        => SimpleNavigation::Renderer::Title
   }
   
   class << self

--- a/lib/simple_navigation/rendering.rb
+++ b/lib/simple_navigation/rendering.rb
@@ -6,5 +6,6 @@ module SimpleNavigation
     autoload :List, 'simple_navigation/rendering/renderer/list'
     autoload :Links, 'simple_navigation/rendering/renderer/links'
     autoload :Breadcrumbs, 'simple_navigation/rendering/renderer/breadcrumbs'
+    autoload :Title, 'simple_navigation/rendering/renderer/title'
   end
 end

--- a/lib/simple_navigation/rendering/renderer/title.rb
+++ b/lib/simple_navigation/rendering/renderer/title.rb
@@ -1,0 +1,22 @@
+module SimpleNavigation
+  module Renderer
+    class Title < SimpleNavigation::Renderer::Base
+      def render(item_container)
+        ([options[:site_name]] + list(item_container)).compact.join(options[:join_with] || " ")
+      end
+
+      private
+
+      def list(item_container)
+        item_container.items.inject([]) do |array, item|
+          if item.selected?
+            array + [item.name] + (include_sub_navigation?(item) ? list(item.sub_navigation) : [])
+          else
+            array
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/lib/simple_navigation/rendering/renderer/title_spec.rb
+++ b/spec/lib/simple_navigation/rendering/renderer/title_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe SimpleNavigation::Renderer::Breadcrumbs do
+
+  describe 'render' do
+
+    def render(current_nav=nil, options={:level => :all})
+      primary_navigation = primary_container
+      select_item(current_nav)
+      setup_renderer_for SimpleNavigation::Renderer::Title, :rails, options
+      @renderer.render(primary_navigation)
+    end
+    context 'regarding result' do
+
+      it "should render the selected page" do
+        render(:invoices).should == "invoices"
+      end
+
+      context 'nested sub_navigation' do
+        it "should add an entry for each selected item" do
+          render(:subnav1).should == "invoices subnav1"
+        end
+      end
+
+      context 'with a site_name specified' do
+        it "should render the site name even when no current_navigation is set" do
+          render(nil, :site_name => "The site").should == "The site"
+        end
+
+        it "should render the site_name before the top level navigation" do
+          render(:users, :site_name => "The site").should == "The site users"
+        end
+      end
+
+      context 'with a custom seperator specified' do
+        it "should separate the items with the separator" do
+          render(:subnav1, :join_with => " | ").should == "invoices | subnav1" 
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi there,

I've taken the liberty of adding an extra renderer to simple-navigation, designed to produce a simple text representation of the current page and parents, for use in the <title> element of web pages. It takes two options - a separator as :join_with (defaults to " " for consistency with the breadcrumb renderer), and site_name, which is prepended to the list of pages if supplied. Please feel free to pull if this is something you think would be useful!

Cheers,

Tim
