### PR TITLE
helpers refactoring - provides additional #active_navigation_item_key met

### DIFF
--- a/lib/simple_navigation/adapters/rails.rb
+++ b/lib/simple_navigation/adapters/rails.rb
@@ -7,8 +7,9 @@ module SimpleNavigation
       def self.register
         SimpleNavigation.set_env(rails_root, rails_env)        
         ActionController::Base.send(:include, SimpleNavigation::Helpers)
-        ActionController::Base.send(:helper_method, :render_navigation)
-        ActionController::Base.send(:helper_method, :active_navigation_item_name)
+        SimpleNavigation::Helpers.instance_methods.each do |m|
+          ActionController::Base.send(:helper_method, m.to_sym)
+        end
       end
       
       def initialize(context)

--- a/lib/simple_navigation/rendering/helpers.rb
+++ b/lib/simple_navigation/rendering/helpers.rb
@@ -32,13 +32,28 @@ module SimpleNavigation
     # * <tt>:items</tt> - you can specify the items directly (e.g. if items are dynamically generated from database). See SimpleNavigation::ItemsProvider for documentation on what to provide as items.
     # * <tt>:renderer</tt> - specify the renderer to be used for rendering the navigation. Either provide the Class or a symbol matching a registered renderer. Defaults to :list (html list renderer).
     def render_navigation(options={})
-      options = apply_defaults(options)
-      load_config(options)
-      active_item_container = SimpleNavigation.active_item_container_for(options[:level])
-      active_item_container.render(options) unless active_item_container.nil?
+      active_navigation_item_container(options) { |container| container && container.render(options) }
     end
 
     # Returns the name of the currently active navigation item belonging to the specified level.
+    #
+    # See Helpers#active_navigation_item for supported options.
+    #
+    # Returns an empty string if no active item can be found for the specified options
+    def active_navigation_item_name(options={})
+      active_navigation_item(options,'') { |item| item.name(:apply_generator => false) }
+    end
+
+    # Returns the key of the currently active navigation item belonging to the specified level.
+    #
+    # See Helpers#active_navigation_item for supported options.
+    #
+    # Returns <tt>nil</tt> if no active item can be found for the specified options
+    def active_navigation_item_key(options={})
+      active_navigation_item(options) { |item| item.key }
+    end
+
+    # Returns the currently active navigation item belonging to the specified level.
     #
     # The following options are supported:
     # * <tt>:level</tt> - defaults to :all which returns the most specific/deepest selected item (the leaf).
@@ -48,35 +63,53 @@ module SimpleNavigation
     #   will be loaded and used for searching the active item.
     # * <tt>:items</tt> - you can specify the items directly (e.g. if items are dynamically generated from database). See SimpleNavigation::ItemsProvider for documentation on what to provide as items.
     #
-    # Returns an empty string if no active item can be found for the specified options
-    def active_navigation_item_name(options={})
-      options = apply_defaults(options)
-      load_config(options)
-      options[:level] = :leaves if options[:level] == :all
-      active_item_container = SimpleNavigation.active_item_container_for(options[:level])
-      if active_item_container && !active_item_container.selected_item.nil?
-        active_item_container.selected_item.name(:apply_generator => false)
-      else
-        ''
+    # Returns the supplied <tt>value_for_nil</tt> object (<tt>nil</tt>
+    # by default) if no active item can be found for the specified
+    # options
+    def active_navigation_item(options={},value_for_nil = nil)
+      options[:level] = :leaves if options[:level].nil? || options[:level] == :all
+      active_navigation_item_container(options) do |container|
+        if container && (item = container.selected_item)
+          block_given? ? yield(item) : item
+        else
+          value_for_nil
+        end
       end
     end
 
-    private
-
-    def load_config(options)
-      ctx = options.delete(:context)
-      SimpleNavigation.init_adapter_from self
-      SimpleNavigation.load_config(ctx) 
-      SimpleNavigation::Configuration.eval_config(ctx) 
-      SimpleNavigation.config.items(options[:items]) if options[:items]
-      SimpleNavigation.handle_explicit_navigation if SimpleNavigation.respond_to?(:handle_explicit_navigation)
-      raise "no primary navigation defined, either use a navigation config file or pass items directly to render_navigation" unless SimpleNavigation.primary_navigation
+    # Returns the currently active item container belonging to the specified level.
+    #
+    # The following options are supported:
+    # * <tt>:level</tt> - defaults to :all which returns the least specific/shallowest selected item.
+    #   Specify a specific level to only look for the selected item in the specified level of navigation (e.g. :level => 1 for primary_navigation etc...).
+    # * <tt>:context</tt> - specifies the context for which you would like to find the active navigation item. Defaults to :default which loads the default navigation.rb (i.e. config/navigation.rb).
+    #   If you specify a context then the plugin tries to load the configuration file for that context, e.g. if you call <tt>active_navigation_item_name(:context => :admin)</tt> the file config/admin_navigation.rb
+    #   will be loaded and used for searching the active item.
+    # * <tt>:items</tt> - you can specify the items directly (e.g. if items are dynamically generated from database). See SimpleNavigation::ItemsProvider for documentation on what to provide as items.
+    #
+    # Returns <tt>nil</tt> if no active item container can be found
+    def active_navigation_item_container(options={})
+      options = SimpleNavigation::Helpers::apply_defaults(options)
+      SimpleNavigation::Helpers::load_config(options,self)
+      container = SimpleNavigation.active_item_container_for(options[:level])
+      block_given? ? yield(container) : container
     end
 
-    def apply_defaults(options)
-      options[:level] = options.delete(:levels) if options[:levels]
-      {:context => :default, :level => :all}.merge(options)
-    end
+    class << self
+      def load_config(options,includer)
+        ctx = options.delete(:context)
+        SimpleNavigation.init_adapter_from includer
+        SimpleNavigation.load_config(ctx)
+        SimpleNavigation::Configuration.eval_config(ctx) 
+        SimpleNavigation.config.items(options[:items]) if options[:items]
+        SimpleNavigation.handle_explicit_navigation if SimpleNavigation.respond_to?(:handle_explicit_navigation)
+        raise "no primary navigation defined, either use a navigation config file or pass items directly to render_navigation" unless SimpleNavigation.primary_navigation
+      end
 
+      def apply_defaults(options)
+        options[:level] = options.delete(:levels) if options[:levels]
+        {:context => :default, :level => :all}.merge(options)
+      end
+    end
   end
 end

--- a/spec/lib/simple_navigation/adapters/rails_spec.rb
+++ b/spec/lib/simple_navigation/adapters/rails_spec.rb
@@ -30,6 +30,9 @@ describe SimpleNavigation::Adapters::Rails do
     it "should install the helper methods in the controller" do
       ActionController::Base.should_receive(:helper_method).with(:render_navigation)
       ActionController::Base.should_receive(:helper_method).with(:active_navigation_item_name)
+      ActionController::Base.should_receive(:helper_method).with(:active_navigation_item_key)
+      ActionController::Base.should_receive(:helper_method).with(:active_navigation_item)
+      ActionController::Base.should_receive(:helper_method).with(:active_navigation_item_container)
       SimpleNavigation.register
     end
     

--- a/spec/lib/simple_navigation/rendering/helpers_spec.rb
+++ b/spec/lib/simple_navigation/rendering/helpers_spec.rb
@@ -7,10 +7,13 @@ describe SimpleNavigation::Helpers do
 
   def blackbox_setup()
     @controller = ControllerMock.new
-    @controller.stub!(:load_config)
+    SimpleNavigation.stub!(:load_config)
+    SimpleNavigation::Configuration.stub!(:eval_config)
     setup_adapter_for :rails
-    primary_navigation = primary_container
-    SimpleNavigation.stub!(:primary_navigation => primary_navigation)
+    @primary_container, @subnav_container = containers
+    @subnav1_item = sub_item(:subnav1)
+    @invoices_item = primary_item(:invoices)
+    SimpleNavigation.stub!(:primary_navigation => @primary_container)
   end
 
   def whitebox_setup
@@ -51,6 +54,76 @@ describe SimpleNavigation::Helpers do
     end
     context 'no active item_container for desired level' do
       it {@controller.active_navigation_item_name(:level => 5).should == ''}
+    end
+  end
+
+  describe 'active_navigation_item_key' do
+    before(:each) do
+      blackbox_setup
+    end
+    context 'active item_container for desired level exists' do
+      context 'container has selected item' do
+        before(:each) do
+          select_item(:subnav1)
+        end
+        it {@controller.active_navigation_item_key(:level => 2).should == :subnav1}
+        it {@controller.active_navigation_item_key.should == :subnav1}
+        it {@controller.active_navigation_item_key(:level => 1).should == :invoices}
+        it {@controller.active_navigation_item_key(:level => :all).should == :subnav1}
+      end
+      context 'container does not have selected item' do
+        it {@controller.active_navigation_item_key.should == nil}
+      end
+    end
+    context 'no active item_container for desired level' do
+      it {@controller.active_navigation_item_key(:level => 5).should == nil}
+    end
+  end
+
+  describe 'active_navigation_item' do
+    before(:each) do
+      blackbox_setup
+    end
+    context 'active item_container for desired level exists' do
+      context 'container has selected item' do
+        before(:each) do
+          select_item(:subnav1)
+        end
+        it {@controller.active_navigation_item(:level => 2).should == @subnav1_item}
+        it {@controller.active_navigation_item.should == @subnav1_item}
+        it {@controller.active_navigation_item(:level => 1).should == @invoices_item}
+        it {@controller.active_navigation_item(:level => :all).should == @subnav1_item}
+      end
+      context 'container does not have selected item' do
+        context 'return value defaults to nil' do
+          it {@controller.active_navigation_item.should == nil}
+        end
+        context 'return value reflects passed in value' do
+          it {@controller.active_navigation_item({},'none').should == 'none'}
+          it {@controller.active_navigation_item({},@invoices_item).should == @invoices_item}
+        end
+      end
+    end
+    context 'no active item_container for desired level' do
+      it {@controller.active_navigation_item(:level => 5).should == nil}
+    end
+  end
+
+  describe 'active_navigation_item_container' do
+    before(:each) do
+      blackbox_setup
+    end
+    context 'active item_container for desired level exists' do
+      before(:each) do
+        select_item(:subnav1)
+      end
+      it {@controller.active_navigation_item_container(:level => 2).should == @subnav_container}
+      it {@controller.active_navigation_item_container.should == @primary_container}
+      it {@controller.active_navigation_item_container(:level => 1).should == @primary_container}
+      it {@controller.active_navigation_item_container(:level => :all).should == @primary_container}
+    end
+    context 'no active item_container for desired level' do
+      it {@controller.active_navigation_item_container(:level => 5).should == nil}
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,18 +48,28 @@ def primary_items
 end
 
 def primary_container
+  containers.first
+end
+
+def containers
   container = SimpleNavigation::ItemContainer.new(1)
   container.dom_id = 'nav_dom_id'
   container.dom_class = 'nav_dom_class'
   @items = primary_items.map {|params| SimpleNavigation::Item.new(container, *params)}
   @items.each {|i| i.stub!(:selected? => false)}
   container.instance_variable_set(:@items, @items)
-  primary_item(:invoices) {|item| item.instance_variable_set(:@sub_navigation, subnav_container)}
-  container
+  sub_container = subnav_container
+  primary_item(:invoices) {|item| item.instance_variable_set(:@sub_navigation, sub_container)}
+  [container,sub_container]
 end
 
 def primary_item(key)
-  yield @items.find {|i| i.key == key}
+  item = @items.find {|i| i.key == key}
+  block_given? ? yield(item) : item
+end
+
+def sub_item(key)
+  primary_item(:invoices).instance_variable_get(:@sub_navigation).items.find { |i| i.key == key}
 end
 
 def select_item(key)


### PR DESCRIPTION
helpers refactoring - provides additional #active_navigation_item_key method and opens up the API by providing #active_navigation_item and #active_navigation_item_container
added test coverage for #active_navigation_item_key, #active_navigation_item and #active_navigation_item_container
reworked private methods in SimpleNavigation::Helpers to module class instance methods instead to prevent ActionController mixin leakage
incorporate new helper methods in rails adapter; refactor helper method addition to iterator over Helpers instance methods
add test coverage for methods newly incorporated in rails adapter
