### PR TITLE
Exception when generating URLs using Sinatra's url helper

### DIFF
--- a/lib/simple_navigation/adapters/sinatra.rb
+++ b/lib/simple_navigation/adapters/sinatra.rb
@@ -3,12 +3,12 @@ require 'cgi'
 module SimpleNavigation
   module Adapters
     class Sinatra < Base
-      
+
       def self.register
         SimpleNavigation.set_env(sinatra_root, sinatra_environment)
         ::Sinatra::Application.send(:helpers, SimpleNavigation::Helpers)
       end
-      
+
       def initialize(context)
         @context = context
         @request = context.request
@@ -18,15 +18,15 @@ module SimpleNavigation
         raise 'no context set for evaluation the config file' unless context
         context
       end
-      
+
       def request_uri
         request.fullpath
       end
-      
+
       def request_path
         request.path
       end
-      
+
       def current_page?(url)
         url_string = CGI.unescape(url)
         if url_string.index("?")
@@ -35,34 +35,34 @@ module SimpleNavigation
           uri = request_uri.split('?').first
         end
         if url_string =~ /^\w+:\/\//
-          url_string == "#{request.protocol}#{request.host_with_port}#{uri}"
+          url_string == "#{request.scheme}://#{request.host_with_port}#{uri}"
         else
           url_string == uri
-        end        
+        end
       end
-      
+
       def link_to(name, url, options={})
         "<a href='#{url}' #{to_attributes(options)}>#{name}</a>"
       end
-      
+
       def content_tag(type, content, options={})
         "<#{type} #{to_attributes(options)}>#{content}</#{type}>"
       end
-      
+
       protected
-      
+
       def self.sinatra_root
         ::Sinatra::Application.root
       end
-      
+
       def self.sinatra_environment
         ::Sinatra::Application.environment
       end
-      
+
       def to_attributes(options)
         options.map {|k, v| "#{k}='#{v}'"}.join(' ')
       end
-      
+
     end
   end
 end

--- a/spec/lib/simple_navigation/adapters/sinatra_spec.rb
+++ b/spec/lib/simple_navigation/adapters/sinatra_spec.rb
@@ -22,18 +22,18 @@ describe SimpleNavigation::Adapters::Sinatra do
       @adapter.context_for_eval.should == @context
     end
   end
-  
+
   describe 'request_uri' do
     it {@adapter.request_uri.should == '/full?param=true'}
   end
-  
+
   describe 'request_path' do
     it {@adapter.request_path.should == '/full'}
   end
-  
+
   describe 'current_page?' do
     before(:each) do
-      @request.stub!(:protocol => 'http://', :host_with_port => 'my_host:5000')
+      @request.stub!(:scheme => 'http', :host_with_port => 'my_host:5000')
     end
     it {@adapter.current_page?('/full?param=true').should be_true}
     it {@adapter.current_page?('/full?param3=true').should be_false}
@@ -41,20 +41,21 @@ describe SimpleNavigation::Adapters::Sinatra do
     it {@adapter.current_page?('http://my_host:5000/full?param=true').should be_true}
     it {@adapter.current_page?('http://my_host:5000/full?param3=true').should be_false}
     it {@adapter.current_page?('http://my_host:5000/full').should be_true}
+    it {@adapter.current_page?('https://my_host:5000/full').should be_false}
     it {@adapter.current_page?('http://my_host:6000/full').should be_false}
     it {@adapter.current_page?('http://my_other_host:5000/full').should be_false}
   end
-  
+
   describe 'link_to' do
     it "should return a link" do
       @adapter.link_to('link', 'url', :class => 'clazz', :id => 'id').should == "<a href='url' class='clazz' id='id'>link</a>"
     end
   end
-  
+
   describe 'content_tag' do
     it "should return a tag" do
       @adapter.content_tag(:div, 'content', :class => 'clazz', :id => 'id').should == "<div class='clazz' id='id'>content</div>"
     end
   end
-  
+
 end


### PR DESCRIPTION
It looks like Rails::Request was confused with Rack::Request as the latter does not have a protocol method (but does have a scheme method, which does essentially the same thing).

Here's a super simple app to demonstrate the issue:

``` ruby
# main.rb
require 'sinatra'
require 'sinatra/simple-navigation'

get '/' do
  render_navigation
end

# config/navigation.rb
SimpleNavigation::Configuration.run do |navigation|
  navigation.items do |primary|
    primary.item :home, 'Overview', url('/')
  end
end
```
