### PR TITLE
current_page? (for Sinatra) does not handle URIs with URI-encoded entities properly

### DIFF
--- a/lib/simple_navigation/adapters/sinatra.rb
+++ b/lib/simple_navigation/adapters/sinatra.rb
@@ -34,6 +34,7 @@ module SimpleNavigation
         else
           uri = request_uri.split('?').first
         end
+        uri = CGI.unescape(uri)
         if url_string =~ /^\w+:\/\//
           url_string == "#{request.scheme}://#{request.host_with_port}#{uri}"
         else

--- a/spec/lib/simple_navigation/adapters/sinatra_spec.rb
+++ b/spec/lib/simple_navigation/adapters/sinatra_spec.rb
@@ -35,15 +35,34 @@ describe SimpleNavigation::Adapters::Sinatra do
     before(:each) do
       @request.stub!(:scheme => 'http', :host_with_port => 'my_host:5000')
     end
-    it {@adapter.current_page?('/full?param=true').should be_true}
-    it {@adapter.current_page?('/full?param3=true').should be_false}
-    it {@adapter.current_page?('/full').should be_true}
-    it {@adapter.current_page?('http://my_host:5000/full?param=true').should be_true}
-    it {@adapter.current_page?('http://my_host:5000/full?param3=true').should be_false}
-    it {@adapter.current_page?('http://my_host:5000/full').should be_true}
-    it {@adapter.current_page?('https://my_host:5000/full').should be_false}
-    it {@adapter.current_page?('http://my_host:6000/full').should be_false}
-    it {@adapter.current_page?('http://my_other_host:5000/full').should be_false}
+
+    describe 'when URL is not encoded' do
+      it {@adapter.current_page?('/full?param=true').should be_true}
+      it {@adapter.current_page?('/full?param3=true').should be_false}
+      it {@adapter.current_page?('/full').should be_true}
+      it {@adapter.current_page?('http://my_host:5000/full?param=true').should be_true}
+      it {@adapter.current_page?('http://my_host:5000/full?param3=true').should be_false}
+      it {@adapter.current_page?('http://my_host:5000/full').should be_true}
+      it {@adapter.current_page?('https://my_host:5000/full').should be_false}
+      it {@adapter.current_page?('http://my_host:6000/full').should be_false}
+      it {@adapter.current_page?('http://my_other_host:5000/full').should be_false}
+    end
+
+    describe 'when URL is encoded' do
+      before(:each) do
+        @request.stub!(:fullpath => '/full%20with%20spaces?param=true', :path => '/full%20with%20spaces')
+      end
+
+      it {@adapter.current_page?('/full%20with%20spaces?param=true').should be_true}
+      it {@adapter.current_page?('/full%20with%20spaces?param3=true').should be_false}
+      it {@adapter.current_page?('/full%20with%20spaces').should be_true}
+      it {@adapter.current_page?('http://my_host:5000/full%20with%20spaces?param=true').should be_true}
+      it {@adapter.current_page?('http://my_host:5000/full%20with%20spaces?param3=true').should be_false}
+      it {@adapter.current_page?('http://my_host:5000/full%20with%20spaces').should be_true}
+      it {@adapter.current_page?('https://my_host:5000/full%20with%20spaces').should be_false}
+      it {@adapter.current_page?('http://my_host:6000/full%20with%20spaces').should be_false}
+      it {@adapter.current_page?('http://my_other_host:5000/full%20with%20spaces').should be_false}
+    end
   end
 
   describe 'link_to' do


### PR DESCRIPTION
The current_page? method in Adapters::Sinatra does not decode the URI when running the comparison. As a result, any URIs with any encoded entities (such as a space) do not match as '%20' != ' '.

Here's a super simple app to demonstrate the issue:

``` ruby
# main.rb
require 'sinatra'
require 'sinatra/simple-navigation'

get '/' do
  render_navigation
end

get '/*/' do |name|
  render_navigation
end

# config/navigation.rb
SimpleNavigation::Configuration.run do |navigation|
  navigation.items do |primary|
    primary.item :home, 'Overview', url('/')
    primary.item :test_page, 'Test Page', url('/test page/')
  end
end
```
