### PR TITLE
highlights_on :auto

### DIFF
--- a/lib/simple_navigation/core/item.rb
+++ b/lib/simple_navigation/core/item.rb
@@ -83,8 +83,10 @@ module SimpleNavigation
           SimpleNavigation.request_uri =~ highlights_on
         when Proc
           highlights_on.call
+        when :auto
+          !!(SimpleNavigation.request_uri =~ /^#{Regexp.escape url_without_anchor}/)
         else
-          raise ArgumentError, ':highlights_on must be a Regexp or Proc'
+          raise ArgumentError, ':highlights_on must be a Regexp, Proc or :auto'
         end
       elsif auto_highlight?
         !!(root_path_match? || SimpleNavigation.current_page?(url_without_anchor))
@@ -114,7 +116,7 @@ module SimpleNavigation
     end
 
     def url_without_anchor
-      url.split('#').first  
+      url.split('#').first
     end
 
   end

--- a/spec/lib/simple_navigation/core/item_spec.rb
+++ b/spec/lib/simple_navigation/core/item_spec.rb
@@ -67,7 +67,7 @@ describe SimpleNavigation::Item do
         end
       end
     end
-    
+
     context 'setting class and id on the container' do
       before(:each) do
         @options = {:container_class => 'container_class', :container_id => 'container_id'}
@@ -100,27 +100,27 @@ describe SimpleNavigation::Item do
         end
       end
     end
-    
+
     context 'url' do
       context 'url is a string' do
         before(:each) do
-          @item = SimpleNavigation::Item.new(@item_container, :my_key, 'name', 'url', {})  
+          @item = SimpleNavigation::Item.new(@item_container, :my_key, 'name', 'url', {})
         end
         it {@item.url.should == 'url'}
       end
       context 'url is a proc' do
         before(:each) do
-          @item = SimpleNavigation::Item.new(@item_container, :my_key, 'name', Proc.new {"my_" + "url"}, {})  
+          @item = SimpleNavigation::Item.new(@item_container, :my_key, 'name', Proc.new {"my_" + "url"}, {})
         end
         it {@item.url.should == 'my_url'}
       end
     end
-    
+
   end
 
   describe 'name' do
     before(:each) do
-      SimpleNavigation.config.stub!(:name_generator => Proc.new {|name| "<span>#{name}</span>"})  
+      SimpleNavigation.config.stub!(:name_generator => Proc.new {|name| "<span>#{name}</span>"})
     end
     context 'default (generator is applied)' do
       it {@item.name.should == "<span>name</span>"}
@@ -331,6 +331,24 @@ describe SimpleNavigation::Item do
         context 'falsey lambda results in no selection' do
           before(:each) do
             @item.stub!(:highlights_on => lambda{false})
+          end
+          it {@item.send(:selected_by_condition?).should be_false}
+        end
+      end
+      context ':highlights_on is :auto' do
+        before(:each) do
+          @item.stub!(:url => '/resources')
+          @item.stub!(:highlights_on => :auto)
+        end
+        context 'we are in a route beginning with this item path' do
+          before(:each) do
+            SimpleNavigation.stub!(:request_uri => '/resources/id')
+          end
+          it {@item.send(:selected_by_condition?).should be_true}
+        end
+        context 'we are in a route not beginning with this item path' do
+          before(:each) do
+            SimpleNavigation.stub!(:request_uri => '/another_resource/id')
           end
           it {@item.send(:selected_by_condition?).should be_false}
         end


### PR DESCRIPTION
Hi!

I've been using your gem for ages and I love it! :)

It's frequent for me to have routes like "users/1" and wanting to have the "users" menu highlighted.

I don't want to have a submenu for every user ID so i thought it would be more useful to highlight all the matching subroutes for "users" like "users/1", "users/3" or "users/comments".

Are you ok with this?
