### PR TITLE
Gretel incompatibility solution proposal

### DIFF
--- a/lib/simple_navigation/adapters/rails.rb
+++ b/lib/simple_navigation/adapters/rails.rb
@@ -72,11 +72,9 @@ module SimpleNavigation
       
       # Extracts a controller from the context.
       def extract_controller_from(context)
-        if context.respond_to? :controller
-          context.controller
-        else
+        context.respond_to?(:controller) ?
+          context.controller || context :
           context
-        end
       end
          
     end


### PR DESCRIPTION
Gretel stubs out controller.controller method to return nil. I've made a workaround for that. All tests pass.

It might have been a better idea to do:

```
context.try(:controller) || context
```

... instead of the code I've written, but it breaks a lot of tests, which it should not.
