### PR TITLE
Allow ItemContainer class to take a block on initialization for ad-hoc dynamic menus

### DIFF
--- a/lib/simple_navigation/core/item_container.rb
+++ b/lib/simple_navigation/core/item_container.rb
@@ -6,11 +6,12 @@ module SimpleNavigation
     attr_reader :items, :level
     attr_accessor :renderer, :dom_id, :dom_class, :auto_highlight
 
-    def initialize(level=1) #:nodoc:
+    def initialize(level=1, &block) #:nodoc:
       @level = level
       @items = []
       @renderer = SimpleNavigation.config.renderer
       @auto_highlight = true
+      yield self if block_given?
     end
 
     # Creates a new navigation item.


### PR DESCRIPTION
The current syntax for ad-hoc menus (generated dynamically) is not good. It is difficult to construct an array of hashes (which might be nested) in a easy to use way.

Allowing the initialize function to take a block enables the following, much better syntax for constructing a menu in-place, and rendering it.

```
SimpleNavigation::ItemContainer.new { |tab|
  tab.item :statement, "Statement", problem_path(@problem)
  tab.item :submit, "Submit", submit_problem_path(@problem) if can? :submit, @problem
}.render
```

It is also quite natural to use. Although - the ItemContainer class would read better if it was named Menu (Though that would probably be a more important deprecation decision).

Notice how this let's me use a CanCan or other `if ...` condition to decide when to show a particular item.

Otherwise it would be annoying to do a temporary array as you currently do:

```
menu = []
menu << {:key => :key, :name => "", ...} if can? ...
```
