### PR TITLE
Subpath shouldn't match partial URL segments. e.g. /resources/1 vs /resources_group/1

### DIFF
--- a/lib/simple_navigation/core/item.rb
+++ b/lib/simple_navigation/core/item.rb
@@ -88,7 +88,7 @@ module SimpleNavigation
         when Proc
           highlights_on.call
         when :subpath
-          !!(SimpleNavigation.request_uri =~ /^#{Regexp.escape url_without_anchor}/)
+          !!(SimpleNavigation.request_uri =~ /^#{Regexp.escape url_without_anchor}(\/|$|\?)/i)
         else
           raise ArgumentError, ':highlights_on must be a Regexp, Proc or :subpath'
         end

--- a/spec/lib/simple_navigation/core/item_spec.rb
+++ b/spec/lib/simple_navigation/core/item_spec.rb
@@ -389,6 +389,12 @@ describe SimpleNavigation::Item do
           end
           it {@item.send(:selected_by_condition?).should be_true}
         end
+        context 'we are in a route that has a similar name' do
+          before(:each) do
+            SimpleNavigation.stub!(:request_uri => '/resources_group/id')
+          end
+          it {@item.send(:selected_by_condition?).should be_false}
+        end
         context 'we are in a route not beginning with this item path' do
           before(:each) do
             SimpleNavigation.stub!(:request_uri => '/another_resource/id')


### PR DESCRIPTION
If you are using subpath it will match

/resources/1

and

/resources_group/1

If subpath is set on resources.

This is not desirable.

Should only match

/resources/*
/resources
/resources?*
/ReSouRces

I added a test, but I couldn't figure out how to run them. I get controller mock undefined errors.
undefined method `request' for #ControllerMock:0x00000003d0d290

However, I'm sure this is something wrong on my end.
