### PR TITLE
Fix compatibity with RSpec 2.12

### DIFF
--- a/spec/lib/simple_navigation/rendering/helpers_spec.rb
+++ b/spec/lib/simple_navigation/rendering/helpers_spec.rb
@@ -89,10 +89,10 @@ describe SimpleNavigation::Helpers do
         before(:each) do
           select_item(:subnav1)
         end
-        it {@controller.active_navigation_item(:level => 2).should == @subnav1_item}
-        it {@controller.active_navigation_item.should == @subnav1_item}
-        it {@controller.active_navigation_item(:level => 1).should == @invoices_item}
-        it {@controller.active_navigation_item(:level => :all).should == @subnav1_item}
+        it {@controller.active_navigation_item(:level => 2).should eq(@subnav1_item)}
+        it {@controller.active_navigation_item.should eq(@subnav1_item)}
+        it {@controller.active_navigation_item(:level => 1).should eq(@invoices_item)}
+        it {@controller.active_navigation_item(:level => :all).should eq(@subnav1_item)}
       end
       context 'container does not have selected item' do
         context 'return value defaults to nil' do
@@ -100,7 +100,7 @@ describe SimpleNavigation::Helpers do
         end
         context 'return value reflects passed in value' do
           it {@controller.active_navigation_item({},'none').should == 'none'}
-          it {@controller.active_navigation_item({},@invoices_item).should == @invoices_item}
+          it {@controller.active_navigation_item({},@invoices_item).should eq(@invoices_item)}
         end
       end
     end


### PR DESCRIPTION
This fixes several test failures with RSpec 2.12, such as bellow:

```
  1) SimpleNavigation::Helpers active_navigation_item active item_container for desired level exists container has selected item 
     Failure/Error: it {@controller.active_navigation_item(:level => 2).should == @subnav1_item}
     ArgumentError:
       wrong number of arguments (1 for 0)
     # /usr/share/gems/gems/rspec-expectations-2.12.1/lib/rspec/matchers/operator_matcher.rb:67:in `uses_generic_implementation_of?'
     # /usr/share/gems/gems/rspec-expectations-2.12.1/lib/rspec/matchers/operator_matcher.rb:34:in `block in use_custom_matcher_or_delegate'
     # /builddir/build/BUILD/rubygem-simple-navigation-3.10.0/usr/share/gems/gems/simple-navigation-3.10.0/spec/lib/simple_navigation/rendering/helpers_spec.rb:92:in `block (5 levels) in <top (required)>'
```
