### PR TITLE
Added json renderer, Issue #129

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ end
 
 group :development do
   gem 'rspec', '>= 2.0.1'
+  gem 'json_spec', '~> 1.1.1'
   gem 'rake'
   gem 'rdoc'
   gem 'jeweler'

--- a/lib/simple_navigation.rb
+++ b/lib/simple_navigation.rb
@@ -25,7 +25,8 @@ module SimpleNavigation
     :list         => SimpleNavigation::Renderer::List,
     :links        => SimpleNavigation::Renderer::Links,
     :breadcrumbs  => SimpleNavigation::Renderer::Breadcrumbs,
-    :text         => SimpleNavigation::Renderer::Text
+    :text         => SimpleNavigation::Renderer::Text,
+    :json         => SimpleNavigation::Renderer::Json
   }
   
   class << self

--- a/lib/simple_navigation/rendering.rb
+++ b/lib/simple_navigation/rendering.rb
@@ -7,5 +7,6 @@ module SimpleNavigation
     autoload :Links, 'simple_navigation/rendering/renderer/links'
     autoload :Breadcrumbs, 'simple_navigation/rendering/renderer/breadcrumbs'
     autoload :Text, 'simple_navigation/rendering/renderer/text'
+    autoload :Json, 'simple_navigation/rendering/renderer/json'
   end
 end

--- a/lib/simple_navigation/rendering/renderer/json.rb
+++ b/lib/simple_navigation/rendering/renderer/json.rb
@@ -1,0 +1,29 @@
+module SimpleNavigation
+  module Renderer
+    
+    # Renders the navigation items as a object tree serialized as a json string, can also output raw ruby Hashes
+    class Json < SimpleNavigation::Renderer::Base
+      
+      def render(item_container)
+        results = hash_render(item_container)
+        results = results.to_json unless options[:as_hash]
+        results
+      end
+
+      private
+
+      def hash_render(item_container)
+        return nil if item_container.nil?
+        item_container.items.map do |item|
+          item_hash = { 
+            :name => item.name, 
+            :url => item.url, 
+            :selected => item.selected?,
+            :items => hash_render(item.sub_navigation)
+          }
+        end        
+      end
+
+    end
+  end
+end

--- a/simple-navigation.gemspec
+++ b/simple-navigation.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Andi Schacke", "Mark J. Titorenko"]
-  s.date = "2013-04-10"
+  s.date = "2013-06-04"
   s.description = "With the simple-navigation gem installed you can easily create multilevel navigations for your Rails, Sinatra or Padrino applications. The navigation is defined in a single configuration file. It supports automatic as well as explicit highlighting of the currently active navigation through regular expressions."
   s.email = "andreas.schacke@gmail.com"
   s.extra_rdoc_files = [
@@ -44,6 +44,7 @@ Gem::Specification.new do |s|
     "lib/simple_navigation/rendering/helpers.rb",
     "lib/simple_navigation/rendering/renderer/base.rb",
     "lib/simple_navigation/rendering/renderer/breadcrumbs.rb",
+    "lib/simple_navigation/rendering/renderer/json.rb",
     "lib/simple_navigation/rendering/renderer/links.rb",
     "lib/simple_navigation/rendering/renderer/list.rb",
     "lib/simple_navigation/rendering/renderer/text.rb",
@@ -60,6 +61,7 @@ Gem::Specification.new do |s|
     "spec/lib/simple_navigation/rendering/helpers_spec.rb",
     "spec/lib/simple_navigation/rendering/renderer/base_spec.rb",
     "spec/lib/simple_navigation/rendering/renderer/breadcrumbs_spec.rb",
+    "spec/lib/simple_navigation/rendering/renderer/json_spec.rb",
     "spec/lib/simple_navigation/rendering/renderer/links_spec.rb",
     "spec/lib/simple_navigation/rendering/renderer/list_spec.rb",
     "spec/lib/simple_navigation/rendering/renderer/text_spec.rb",
@@ -70,7 +72,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--inline-source", "--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubyforge_project = "andi"
-  s.rubygems_version = "1.8.24"
+  s.rubygems_version = "1.8.25"
   s.summary = "simple-navigation is a ruby library for creating navigations (with multiple levels) for your Rails2, Rails3, Sinatra or Padrino application."
 
   if s.respond_to? :specification_version then
@@ -79,12 +81,14 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<activesupport>, [">= 2.3.2"])
       s.add_development_dependency(%q<rspec>, [">= 2.0.1"])
+      s.add_development_dependency(%q<json_spec>, ["~> 1.1.1"])
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_development_dependency(%q<rdoc>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
     else
       s.add_dependency(%q<activesupport>, [">= 2.3.2"])
       s.add_dependency(%q<rspec>, [">= 2.0.1"])
+      s.add_dependency(%q<json_spec>, ["~> 1.1.1"])
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<rdoc>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
@@ -92,6 +96,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<activesupport>, [">= 2.3.2"])
     s.add_dependency(%q<rspec>, [">= 2.0.1"])
+    s.add_dependency(%q<json_spec>, ["~> 1.1.1"])
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<rdoc>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])

--- a/spec/lib/simple_navigation/rendering/renderer/json_spec.rb
+++ b/spec/lib/simple_navigation/rendering/renderer/json_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe SimpleNavigation::Renderer::Json do
+
+  describe 'render' do
+
+    def render(current_nav=nil, options={})
+      primary_navigation = primary_container
+      select_item(current_nav)
+      setup_renderer_for SimpleNavigation::Renderer::Json, :rails, options
+      @renderer.render(primary_navigation)
+    end
+
+    def prerendered_menu
+      '[{"name":"users","url":"first_url","selected":false,"items":null},{"name":"invoices","url":"second_url","selected":true,"items":[{"name":"subnav1","url":"subnav1_url","selected":false,"items":null},{"name":"subnav2","url":"subnav2_url","selected":false,"items":null}]},{"name":"accounts","url":"third_url","selected":false,"items":null},{"name":"miscellany","url":null,"selected":false,"items":null}]'
+    end
+
+    context 'regarding result' do
+
+      it "should return a string" do
+        render(:invoices).class.should == String
+      end
+
+      it "should render the selected page" do
+        json = parse_json(render(:invoices))
+        found = json.any? do |item| 
+          item["name"] == "invoices" and item["selected"]
+        end
+        found.should == true
+      end
+
+    end
+
+    context 'regarding hash result' do
+      it "should return a hash" do
+        render(:invoices, :as_hash => true).class.should == Array
+      end
+
+      it "should render the selected page" do
+        found = render(:invoices, :as_hash => true).any? do |item|
+          item[:name] == "invoices" and item[:selected]
+        end
+        found.should == true
+      end
+
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 ENV["RAILS_ENV"] = "test"
 require 'rubygems'
 require 'rspec'
+require 'json_spec'
 require 'action_controller'
 
 module Rails
@@ -28,7 +29,7 @@ RSpec.configure do |config|
   # config.mock_with :flexmock
   # config.mock_with :rr
   config.mock_with :rspec
-
+  config.include JsonSpec::Helpers
 end
 
 # spec helper methods


### PR DESCRIPTION
The json renderer outputs a json string representing the full menu. This renderer can be useful when implementing a custom javascript menu.

The top level object is an array containing the top level menu items, every menu item has the name, url, selected and items keys. The items properties contains either the array of the sub menu items or null where it is a leaf node.

You can invoke the renderer on the following way:

``` ruby
render_navigation(:renderer => :json)
```

Most of the time you'll want the menu to be assigned directly on javascript, on those cases you'll problably would want to avoid the output to be escaped:

``` ruby
<%= raw render_navigation(:renderer => :json) %>
```

You can also use this renderer to get the menu as a ruby Hash, to do so you need to set the option `:as_hash` to true:

``` ruby
render_navigation(:renderer => :json, :as_hash => true)
```

Please be aware that even when requesting the output as a hash the results is actually an array where every item is a hash object.
