### PR TITLE
Adding License to Gemspec

### DIFF
--- a/simple-navigation.gemspec
+++ b/simple-navigation.gemspec
@@ -5,6 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "simple-navigation"
+  s.license = "MIT"
   s.version = "3.11.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=


### PR DESCRIPTION
Adding License to Gemspec makes it easier for tools such as https://github.com/pivotal/LicenseFinder to find license of Gems.
