### PR TITLE
[#139] html_safe config

### DIFF
--- a/lib/simple_navigation/adapters/rails.rb
+++ b/lib/simple_navigation/adapters/rails.rb
@@ -39,7 +39,7 @@ module SimpleNavigation
       end
       
       def link_to(name, url, options={})
-        template.link_to(html_safe(name), url, options) if template
+        template.link_to(link_title(name), url, options) if template
       end
       
       def content_tag(type, content, options={})
@@ -75,6 +75,10 @@ module SimpleNavigation
         context.respond_to?(:controller) ?
           context.controller || context :
           context
+      end
+
+      def link_title name
+        SimpleNavigation.config.consider_item_names_as_safe ? html_safe(name) : name
       end
          
     end

--- a/lib/simple_navigation/core/configuration.rb
+++ b/lib/simple_navigation/core/configuration.rb
@@ -6,7 +6,7 @@ module SimpleNavigation
   class Configuration
     include Singleton
 
-    attr_accessor :renderer, :selected_class, :active_leaf_class, :autogenerate_item_ids, :id_generator, :auto_highlight, :name_generator
+    attr_accessor :renderer, :selected_class, :active_leaf_class, :autogenerate_item_ids, :id_generator, :auto_highlight, :name_generator, :consider_item_names_as_safe
     attr_reader :primary_navigation
 
     class << self
@@ -32,6 +32,10 @@ module SimpleNavigation
       @id_generator = Proc.new {|id| id.to_s }
       @name_generator = Proc.new {|name| name}
       @auto_highlight = true
+      @consider_item_names_as_safe = true
+      if defined?(ActiveSupport::Deprecation)
+        ActiveSupport::Deprecation.warn "consider_item_names_as_safe will be set to false by default in 3.13.0 release", caller
+      end
     end
 
     # This is the main method for specifying the navigation items. It can be used in two ways:

--- a/spec/lib/simple_navigation/adapters/rails_spec.rb
+++ b/spec/lib/simple_navigation/adapters/rails_spec.rb
@@ -14,7 +14,7 @@ describe SimpleNavigation::Adapters::Rails do
     @template = stub(:template, :request => @request)
     @adapter = create_adapter
   end
-  
+
   describe 'self.register' do
     before(:each) do
       ActionController::Base.stub!(:include)
@@ -268,7 +268,24 @@ describe SimpleNavigation::Adapters::Rails do
       it {@adapter.send(:html_safe, @input).should == @input}
     end
   end
-  
+
+  describe 'link_title' do
+    before(:each) do
+      @safe = double :safe
+      @name = double :name, html_safe: @safe
+    end
+    context 'consider item names are safe' do
+      it {@adapter.send(:link_title, @name) == @safe}
+    end
+    context 'consider item names are not safe' do
+      before do
+        SimpleNavigation.config.consider_item_names_as_safe = false
+        @adapter.stub template: @template
+      end
+      it {@adapter.send(:link_title, @name) == @name}
+    end
+  end
+
   describe 'template_from' do
     context 'Rails3' do 
       before(:each) do
@@ -283,5 +300,5 @@ describe SimpleNavigation::Adapters::Rails do
       it {@adapter.send(:template_from, @controller).should == 'view'}
     end
   end
-  
+
 end


### PR DESCRIPTION
pull request about issue https://github.com/andi/simple-navigation/issues/139

I think doing 

``` ruby
@consider_item_names_as_safe = false
```

by default is kind of weird, because developers write menu code by himself and won't do things like this

``` ruby
SimpleNavigation::Configuration.run do |nav|
  nav.items do |top|
    top.item :hack, "<script>alert('hacked!');</script>", '#'
  end
end
```

comments and suggestions about request are welcome!
