### PR TITLE
Add #dom_attributes option to ItemContainer.

### DIFF
--- a/generators/navigation_config/templates/config/navigation.rb
+++ b/generators/navigation_config/templates/config/navigation.rb
@@ -63,10 +63,9 @@ SimpleNavigation::Configuration.run do |navigation|
     primary.item :key_3, 'Admin', url, :class => 'special', :if => Proc.new { current_user.admin? }
     primary.item :key_4, 'Account', url, :unless => Proc.new { logged_in? }
 
-    # you can also specify a css id or class to attach to this particular level
+    # you can also specify html attributes to attach to this particular level
     # works for all levels of the menu
-    # primary.dom_id = 'menu-id'
-    # primary.dom_class = 'menu-class'
+    # primary.dom_attributes = {id: 'menu-id', class: 'menu-class'}
 
     # You can turn off auto highlighting for a specific level
     # primary.auto_highlight = false

--- a/lib/simple_navigation/core/item.rb
+++ b/lib/simple_navigation/core/item.rb
@@ -13,6 +13,7 @@ module SimpleNavigation
       options = setup_url_and_options(url_or_options, options_or_nil)
       @container.dom_class = options.delete(:container_class) if options[:container_class]
       @container.dom_id = options.delete(:container_id) if options[:container_id]
+      @container.dom_attributes = options[:container_attributes] ? options.delete(:container_attributes) : {}
       @container.selected_class = options.delete(:selected_class) if options[:selected_class]
       @key = key
       @method = options.delete(:method)

--- a/lib/simple_navigation/core/item_container.rb
+++ b/lib/simple_navigation/core/item_container.rb
@@ -4,13 +4,18 @@ module SimpleNavigation
   class ItemContainer
 
     attr_reader :items, :level
-    attr_accessor :renderer, :dom_id, :dom_class, :auto_highlight, :selected_class
+    attr_accessor :renderer, :dom_id, :dom_class, :dom_attributes, :auto_highlight, :selected_class
 
     def initialize(level=1) #:nodoc:
       @level = level
       @items = []
       @renderer = SimpleNavigation.config.renderer
       @auto_highlight = true
+    end
+
+    def dom_attributes
+      # backward compability for #dom_id and #dom_class
+      (@dom_attributes || {}).merge({id: dom_id, class: dom_class}.reject{|k, v| v.nil?})
     end
 
     # Creates a new navigation item.

--- a/lib/simple_navigation/rendering/renderer/breadcrumbs.rb
+++ b/lib/simple_navigation/rendering/renderer/breadcrumbs.rb
@@ -6,7 +6,7 @@ module SimpleNavigation
     #
     # By default, the renderer sets the item's key as dom_id for the rendered <a> element unless the config option <tt>autogenerate_item_ids</tt> is set to false.
     # The id can also be explicitely specified by setting the id in the html-options of the 'item' method in the config/navigation.rb file.
-    # The ItemContainer's dom_class and dom_id are applied to the surrounding <div> element.
+    # The ItemContainer's dom_attributes are applied to the surrounding <div> element.
     #
     class Breadcrumbs < SimpleNavigation::Renderer::Base
 
@@ -14,7 +14,7 @@ module SimpleNavigation
         content = a_tags(item_container).join(join_with)
         content_tag(:div,
           prefix_for(content) + content,
-          {:id => item_container.dom_id, :class => item_container.dom_class})
+          item_container.dom_attributes)
       end
 
       protected

--- a/lib/simple_navigation/rendering/renderer/links.rb
+++ b/lib/simple_navigation/rendering/renderer/links.rb
@@ -8,14 +8,14 @@ module SimpleNavigation
     #
     # By default, the renderer sets the item's key as dom_id for the rendered <a> element unless the config option <tt>autogenerate_item_ids</tt> is set to false.
     # The id can also be explicitely specified by setting the id in the html-options of the 'item' method in the config/navigation.rb file.
-    # The ItemContainer's dom_class and dom_id are applied to the surrounding <div> element.
+    # The ItemContainer's dom_attributes are applied to the surrounding <div> element.
     #
     class Links < SimpleNavigation::Renderer::Base
       def render(item_container)
         div_content = item_container.items.inject([]) do |list, item|
           list << tag_for(item)
         end.join(join_with)
-        content_tag(:div, div_content, {:id => item_container.dom_id, :class => item_container.dom_class})
+        content_tag(:div, div_content, item_container.dom_attributes)
       end
 
       protected

--- a/lib/simple_navigation/rendering/renderer/list.rb
+++ b/lib/simple_navigation/rendering/renderer/list.rb
@@ -21,7 +21,7 @@ module SimpleNavigation
         if skip_if_empty? && item_container.empty?
           ''
         else  
-          content_tag((options[:ordered] ? :ol : :ul), list_content, {:id => item_container.dom_id, :class => item_container.dom_class}) 
+          content_tag((options[:ordered] ? :ol : :ul), list_content, item_container.dom_attributes) 
         end
       end
     end

--- a/spec/lib/simple_navigation/core/item_spec.rb
+++ b/spec/lib/simple_navigation/core/item_spec.rb
@@ -70,10 +70,11 @@ describe SimpleNavigation::Item do
 
     context 'setting class and id on the container' do
       before(:each) do
-        @options = {:container_class => 'container_class', :container_id => 'container_id'}
+        @options = {:container_class => 'container_class', :container_id => 'container_id', :container_attributes => {'ng-show' => 'false'}}
       end
-      it {@item_container.should_receive(:dom_class=).with('container_class')}
-      it {@item_container.should_receive(:dom_id=).with('container_id')}
+      it "fills in #dom_attributes" do
+        @item_container.dom_attributes.should == {'id' => 'container_id', 'class' => 'container_class', 'ng-show' => 'false'}
+      end
       after(:each) do
         SimpleNavigation::Item.new(@item_container, :my_key, 'name', 'url', @options)
       end


### PR DESCRIPTION
This allows you to define other html attributes than :id and :class on menu container. I needed this in order to define some 'ng-...' attributes on `<ul>` element, which was impossible for me without this change.

This includes backward compability for `item_container.dom_id=` and `item_container.dom_class=`, so the old way of setting it is still okay and won't be broken.
