### PR TITLE
A more powerful name_generator

### DIFF
--- a/generators/navigation_config/templates/config/navigation.rb
+++ b/generators/navigation_config/templates/config/navigation.rb
@@ -24,7 +24,7 @@ SimpleNavigation::Configuration.run do |navigation|
 
   # If you need to add custom html around item names, you can define a proc that will be called with the name you pass in to the navigation.
   # The example below shows how to wrap items spans.
-  # navigation.name_generator = Proc.new {|name| "<span>#{name}</span>"}
+  # navigation.name_generator = Proc.new {|name, item| "<span>#{name}</span>"}
 
   # The auto highlight feature is turned on by default.
   # This turns it off globally (for the whole plugin)

--- a/lib/simple_navigation/core/item.rb
+++ b/lib/simple_navigation/core/item.rb
@@ -31,7 +31,7 @@ module SimpleNavigation
     def name(options = {})
       options.reverse_merge!(:apply_generator => true)
       if (options[:apply_generator])
-        SimpleNavigation.config.name_generator.call(@name)
+        SimpleNavigation.config.name_generator.call(@name, self)
       else
         @name
       end

--- a/spec/lib/simple_navigation/core/item_spec.rb
+++ b/spec/lib/simple_navigation/core/item_spec.rb
@@ -196,9 +196,22 @@ module SimpleNavigation
           name_generator: proc{ |name| "<span>#{name}</span>" })
       end
 
-      context "when no option is given" do
-        it "uses the default name_generator" do
-          expect(item.name).to eq '<span>name</span>'
+      context 'when no option is given' do
+        context 'and the name_generator uses only the name' do
+          it 'uses the default name_generator' do
+            expect(item.name).to eq '<span>name</span>'
+          end
+        end
+
+        context 'and the name_generator uses only the item itself' do
+          before do
+            SimpleNavigation.config.stub(
+              name_generator: proc{ |name, item| "<span>#{item.key}</span>" })
+          end
+
+          it 'uses the default name_generator' do
+            expect(item.name).to eq '<span>my_key</span>'
+          end
         end
       end
 


### PR DESCRIPTION
I'm trying to use Font-Awesome in my menu and I'm using `name_generator` to do so but I think using the name of the menu entry doesn't really make sense since it can change depending of the language.

I'd like to submit a PR to provide access to `self` in this block. There are two ways to do so, one which is not retro-compatible, passing `self` instead of just `@name`. The second is more conservative, it's just passing `self` as second argument.

What do you think?
