### PR TITLE
Removing future rspec deprecations

### DIFF
--- a/spec/initializers/have_css_matcher.rb
+++ b/spec/initializers/have_css_matcher.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :have_css do |expected, times|
   match do |actual|
-    HTML::Selector.new(expected).select(actual).should have_at_least(times || 1).entry
+    expect(HTML::Selector.new(expected).select(actual).size).to be >= (times || 1)
   end
 
   failure_message_for_should do |actual|

--- a/spec/lib/simple_navigation/core/configuration_spec.rb
+++ b/spec/lib/simple_navigation/core/configuration_spec.rb
@@ -49,11 +49,11 @@ module SimpleNavigation
       end
 
       it 'sets autogenerate_item_ids to true as default' do
-        expect(config.autogenerate_item_ids).to be_true
+        expect(config.autogenerate_item_ids).to be_truthy
       end
 
       it 'sets auto_highlight to true as default' do
-        expect(config.auto_highlight).to be_true
+        expect(config.auto_highlight).to be_truthy
       end
 
       it 'should set the id_generator' do

--- a/spec/lib/simple_navigation/core/item_spec.rb
+++ b/spec/lib/simple_navigation/core/item_spec.rb
@@ -65,7 +65,7 @@ module SimpleNavigation
 
         it 'sets the html options without the method' do
           meth = item.instance_variable_get(:@html_options).key?(:method)
-          expect(meth).to be_false
+          expect(meth).to be_falsey
         end
       end
 
@@ -581,7 +581,7 @@ module SimpleNavigation
           let(:url) { '/' }
 
           it 'returns true' do
-            expect(item.send(:root_path_match?)).to be_true
+            expect(item.send(:root_path_match?)).to be_truthy
           end
         end
 
@@ -589,7 +589,7 @@ module SimpleNavigation
           let(:url) { '/other' }
 
           it 'returns false' do
-            expect(item.send(:root_path_match?)).to be_false
+            expect(item.send(:root_path_match?)).to be_falsey
           end
         end
       end
@@ -601,7 +601,7 @@ module SimpleNavigation
           let(:url) { '/' }
 
           it 'returns false' do
-            expect(item.send(:root_path_match?)).to be_false
+            expect(item.send(:root_path_match?)).to be_falsey
           end
         end
 
@@ -609,7 +609,7 @@ module SimpleNavigation
           let(:url) { nil }
 
           it 'returns false' do
-            expect(item.send(:root_path_match?)).to be_false
+            expect(item.send(:root_path_match?)).to be_falsey
           end
         end
       end
@@ -620,7 +620,7 @@ module SimpleNavigation
         before { adapter.stub(request_path: '/other') }
 
         it 'returns false' do
-          expect(item.send(:root_path_match?)).to be_false
+          expect(item.send(:root_path_match?)).to be_falsey
         end
       end
 
@@ -630,7 +630,7 @@ module SimpleNavigation
         before { adapter.stub(request_path: '/other') }
 
         it 'returns false' do
-          expect(item.send(:root_path_match?)).to be_false
+          expect(item.send(:root_path_match?)).to be_falsey
         end
       end
     end
@@ -647,7 +647,7 @@ module SimpleNavigation
           before { item_container.stub(auto_highlight: true) }
 
           it 'returns true' do
-            expect(item.send(:auto_highlight?)).to be_true
+            expect(item.send(:auto_highlight?)).to be_truthy
           end
         end
 
@@ -655,7 +655,7 @@ module SimpleNavigation
           before { item_container.stub(auto_highlight: false) }
 
           it 'returns false' do
-            expect(item.send(:auto_highlight?)).to be_false
+            expect(item.send(:auto_highlight?)).to be_falsey
           end
         end
       end
@@ -667,7 +667,7 @@ module SimpleNavigation
           before { item_container.stub(auto_highlight: true) }
 
           it 'returns false' do
-            expect(item.send(:auto_highlight?)).to be_false
+            expect(item.send(:auto_highlight?)).to be_falsey
           end
         end
 
@@ -675,7 +675,7 @@ module SimpleNavigation
           before { item_container.stub(auto_highlight: false) }
 
           it 'returns false' do
-            expect(item.send(:auto_highlight?)).to be_false
+            expect(item.send(:auto_highlight?)).to be_falsey
           end
         end
       end

--- a/spec/lib/simple_navigation/rails_controller_methods_spec.rb
+++ b/spec/lib/simple_navigation/rails_controller_methods_spec.rb
@@ -45,7 +45,7 @@ module SimpleNavigation
         context 'when the navigation method is not called' do
           it "doesn't have any instance method called 'sn_set_navigation'" do
             has_method = controller.respond_to?(:sn_set_navigation, true)
-            expect(has_method).to be_false
+            expect(has_method).to be_falsey
           end
         end
 
@@ -56,7 +56,7 @@ module SimpleNavigation
 
           it 'creates an instance method called "sn_set_navigation"' do
             has_method = controller.respond_to?(:sn_set_navigation, true)
-            expect(has_method).to be_true
+            expect(has_method).to be_truthy
           end
 
           it 'does not create a public method' do

--- a/spec/lib/simple_navigation/rendering/renderer/base_spec.rb
+++ b/spec/lib/simple_navigation/rendering/renderer/base_spec.rb
@@ -44,7 +44,7 @@ module SimpleNavigation
             let(:options) {{ expand_all: true }}
 
             it 'returns true' do
-              expect(base.expand_all?).to be_true
+              expect(base.expand_all?).to be_truthy
             end
           end
 
@@ -52,7 +52,7 @@ module SimpleNavigation
             let(:options) {{ expand_all: false }}
 
             it 'returns false' do
-              expect(base.expand_all?).to be_false
+              expect(base.expand_all?).to be_falsey
             end
           end
         end
@@ -61,7 +61,7 @@ module SimpleNavigation
           let(:options) { Hash.new }
 
           it 'returns false' do
-            expect(base.expand_all?).to be_false
+            expect(base.expand_all?).to be_falsey
           end
         end
       end
@@ -72,7 +72,7 @@ module SimpleNavigation
             let(:options) {{ skip_if_empty: true }}
 
             it 'returns true' do
-              expect(base.skip_if_empty?).to be_true
+              expect(base.skip_if_empty?).to be_truthy
             end
           end
 
@@ -80,7 +80,7 @@ module SimpleNavigation
             let(:options) {{ skip_if_empty: false }}
 
             it 'returns true' do
-              expect(base.skip_if_empty?).to be_false
+              expect(base.skip_if_empty?).to be_falsey
             end
           end
         end
@@ -89,7 +89,7 @@ module SimpleNavigation
           let(:options) { Hash.new }
 
           it 'returns true' do
-            expect(base.skip_if_empty?).to be_false
+            expect(base.skip_if_empty?).to be_falsey
           end
         end
       end
@@ -121,7 +121,7 @@ module SimpleNavigation
           let(:sub_navigation) { nil }
 
           it 'returns false' do
-            expect(base.send(:consider_sub_navigation?, item)).to be_false
+            expect(base.send(:consider_sub_navigation?, item)).to be_falsey
           end
         end
 
@@ -132,7 +132,7 @@ module SimpleNavigation
             before { base.stub(level: 'unknown') }
 
             it 'returns false' do
-              expect(base.send(:consider_sub_navigation?, item)).to be_false
+              expect(base.send(:consider_sub_navigation?, item)).to be_falsey
             end
           end
 
@@ -140,7 +140,7 @@ module SimpleNavigation
             before { base.stub(level: :all) }
 
             it 'returns false' do
-              expect(base.send(:consider_sub_navigation?, item)).to be_true
+              expect(base.send(:consider_sub_navigation?, item)).to be_truthy
             end
           end
 
@@ -148,7 +148,7 @@ module SimpleNavigation
             before { base.stub(level: 2) }
 
             it 'returns false' do
-              expect(base.send(:consider_sub_navigation?, item)).to be_false
+              expect(base.send(:consider_sub_navigation?, item)).to be_falsey
             end
           end
 
@@ -159,7 +159,7 @@ module SimpleNavigation
               before { sub_navigation.stub(level: 4) }
 
               it 'returns false' do
-                expect(base.send(:consider_sub_navigation?, item)).to be_false
+                expect(base.send(:consider_sub_navigation?, item)).to be_falsey
               end
             end
 
@@ -167,7 +167,7 @@ module SimpleNavigation
               before { sub_navigation.stub(level: 3) }
 
               it 'returns true' do
-                expect(base.send(:consider_sub_navigation?, item)).to be_true
+                expect(base.send(:consider_sub_navigation?, item)).to be_truthy
               end
             end
 
@@ -175,7 +175,7 @@ module SimpleNavigation
               before { sub_navigation.stub(level: 2) }
 
               it 'returns true' do
-                expect(base.send(:consider_sub_navigation?, item)).to be_true
+                expect(base.send(:consider_sub_navigation?, item)).to be_truthy
               end
             end
           end
@@ -192,7 +192,7 @@ module SimpleNavigation
             before { base.stub(expand_sub_navigation?: true) }
 
             it 'returns true' do
-              expect(base.include_sub_navigation?(item)).to be_true
+              expect(base.include_sub_navigation?(item)).to be_truthy
             end
           end
 
@@ -200,7 +200,7 @@ module SimpleNavigation
             before { base.stub(expand_sub_navigation?: false) }
 
             it 'returns false' do
-              expect(base.include_sub_navigation?(item)).to be_false
+              expect(base.include_sub_navigation?(item)).to be_falsey
             end
           end
         end
@@ -212,7 +212,7 @@ module SimpleNavigation
             before { base.stub(expand_sub_navigation?: true) }
 
             it 'returns false' do
-              expect(base.include_sub_navigation?(item)).to be_false
+              expect(base.include_sub_navigation?(item)).to be_falsey
             end
           end
 
@@ -220,7 +220,7 @@ module SimpleNavigation
             before { base.stub(expand_sub_navigation?: false) }
 
             it 'returns false' do
-              expect(base.include_sub_navigation?(item)).to be_false
+              expect(base.include_sub_navigation?(item)).to be_falsey
             end
           end
         end

--- a/spec/lib/simple_navigation/rendering/renderer/links_spec.rb
+++ b/spec/lib/simple_navigation/rendering/renderer/links_spec.rb
@@ -64,7 +64,7 @@ module SimpleNavigation
           let(:options) {{ level: :all, join_with: ' | ' }}
 
           it 'separates the items with the specified separator' do
-            expect(raw_output.scan(' | ')).to have(3).items
+            expect(raw_output.scan(' | ').size).to eq 3
           end
         end
 

--- a/spec/lib/simple_navigation_spec.rb
+++ b/spec/lib/simple_navigation_spec.rb
@@ -87,7 +87,7 @@ describe SimpleNavigation do
       before { subject.stub(config_file: 'file') }
 
       it 'returns true' do
-        expect(subject.config_file?).to be_true
+        expect(subject.config_file?).to be_truthy
       end
     end
 
@@ -95,7 +95,7 @@ describe SimpleNavigation do
       before { subject.stub(config_file: nil) }
 
       it 'returns false' do
-        expect(subject.config_file?).to be_false
+        expect(subject.config_file?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
This commit removes deprecations planned in the next RSpec release:
- `be_false` is changed to `be_falsey`
- `be_true` is changed to `be_truthy`
- `have(n).items` is changed to `expect(x.size).to eq(n)`
