### PR TITLE
Rails 4.2 compatibility fixes.

### DIFF
--- a/spec/initializers/have_css_matcher.rb
+++ b/spec/initializers/have_css_matcher.rb
@@ -1,10 +1,10 @@
 RSpec::Matchers.define :have_css do |expected, times|
   match do |actual|
-    selector = HTML::Selector.new(expected).select(actual)
+    selection = HTMLSelector.new(Array(expected), actual).select
     if times
-      expect(selector.size).to eq times
+      expect(selection.size).to eq times
     else
-      expect(selector.size).to be >= 1
+      expect(selection.size).to be >= 1
     end
   end
 

--- a/spec/simple_navigation/renderer/breadcrumbs_spec.rb
+++ b/spec/simple_navigation/renderer/breadcrumbs_spec.rb
@@ -7,7 +7,7 @@ module SimpleNavigation
 
       let(:item) { nil }
       let(:options) {{ level: :all }}
-      let(:output) { HTML::Document.new(raw_output).root }
+      let(:output) { Loofah.document(raw_output) }
       let(:raw_output) { renderer.render(navigation) }
       let(:renderer) { Breadcrumbs.new(options) }
 

--- a/spec/simple_navigation/renderer/links_spec.rb
+++ b/spec/simple_navigation/renderer/links_spec.rb
@@ -8,7 +8,7 @@ module SimpleNavigation
 
         let(:item) { nil }
         let(:options) {{ level: :all }}
-        let(:output) { HTML::Document.new(raw_output).root }
+        let(:output) { Loofah.document(raw_output) }
         let(:raw_output) { renderer.render(navigation) }
         let(:renderer) { Links.new(options) }
 
@@ -31,7 +31,7 @@ module SimpleNavigation
         end
 
         it "renders the 'a' tags with the corresponding item's :html_options" do
-          expect(output).to have_css('a[style=float:right]')
+          expect(output).to have_css('a[style="float:right"]')
         end
 
         context 'when an item has a specified id' do

--- a/spec/simple_navigation/renderer/list_spec.rb
+++ b/spec/simple_navigation/renderer/list_spec.rb
@@ -7,7 +7,7 @@ module SimpleNavigation
 
       let(:item) { nil }
       let(:options) {{ level: :all }}
-      let(:output) { HTML::Document.new(raw_output).root }
+      let(:output) { Loofah.document(raw_output) }
       let(:raw_output) { renderer.render(navigation) }
       let(:renderer) { List.new(options) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'initializers/have_css_matcher'
 require 'initializers/memfs'
+require 'rails'
 require 'action_controller'
+require 'rails-dom-testing'
 require 'coveralls'
 require 'action_view'
 


### PR DESCRIPTION
This contains some fixes needed for Rails 4.2 compatibility.

However, please note that there are still some remaining issues with "SimpleNavigation::Adapters::Rails.register" tests. Also, I tested this patch just against Rails 4.2 and moreover, I tested this changes just with S-N 3.14.0 and later forward ported them, so there is probably missing something more. But I hope you can use this PR for inspiration at least ;)