### PR TITLE
Remove dependency on classic-style Sinatra applications and enable use with modular-style apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * `ConfigFileFinder` and `ConfigFile` handle the configuration logic
 * File organization was been changed to reflect the Ruby namespacing
 
+## 3.15.0
+
+* Remove dependency on classic-style Sinatra applications and enable use with modular-style apps
+
 ## 3.13.0
 
 * consider_item_names_as_safe is now false by default. Removed deprecation warning

--- a/lib/simple_navigation/adapters/sinatra.rb
+++ b/lib/simple_navigation/adapters/sinatra.rb
@@ -3,9 +3,8 @@ require 'cgi'
 module SimpleNavigation
   module Adapters
     class Sinatra < Base
-      def self.register
-        SimpleNavigation.set_env(sinatra_root, sinatra_environment)
-        ::Sinatra::Application.send(:helpers, SimpleNavigation::Helpers)
+      def self.register(app)
+        SimpleNavigation.set_env(app.root, app.environment)
       end
 
       def initialize(context)
@@ -49,14 +48,6 @@ module SimpleNavigation
       end
 
       protected
-
-      def self.sinatra_root
-        ::Sinatra::Application.root
-      end
-
-      def self.sinatra_environment
-        ::Sinatra::Application.environment
-      end
 
       def to_attributes(options)
         options.map { |k, v| v.nil? ? '' : " #{k}='#{v}'" }.join

--- a/lib/simple_navigation/version.rb
+++ b/lib/simple_navigation/version.rb
@@ -1,3 +1,3 @@
 module SimpleNavigation
-  VERSION = '3.13.0'
+  VERSION = '3.15.0'
 end


### PR DESCRIPTION
See discussion in https://github.com/codeplant/sinatra-simple-navigation/issues/4