### PR TITLE
Fix uninitialized constant Rails::Railtie (NameError)

### DIFF
--- a/lib/simple_navigation.rb
+++ b/lib/simple_navigation.rb
@@ -12,7 +12,7 @@ require 'simple_navigation/items_provider'
 require 'simple_navigation/renderer'
 require 'simple_navigation/adapters'
 require 'simple_navigation/config_file_finder'
-require 'simple_navigation/railtie' if defined?(::Rails)
+require 'simple_navigation/railtie' if defined?(::Rails::Railtie)
 
 require 'forwardable'
 


### PR DESCRIPTION
This happens when launching tests on https://github.com/n-rodriguez/simple_navigation_renderers (Travis : https://travis-ci.org/n-rodriguez/simple_navigation_renderers)