### PR TITLE
Posibility insert string before and after link

### DIFF
--- a/lib/simple_navigation/item.rb
+++ b/lib/simple_navigation/item.rb
@@ -60,13 +60,13 @@ module SimpleNavigation
     end
     
     # Return string from options for insert before link.
-    def html_before
-      options.fetch(:html_before, '')
+    def content_before
+      options.fetch(:content_before, '')
     end
   
     # Return string from options for insert after link.
-    def html_after
-      options.fetch(:html_after, '')
+    def content_after
+      options.fetch(:content_after, '')
     end    
 
     # Returns the configured active_leaf_class if the item is the selected leaf,

--- a/lib/simple_navigation/item.rb
+++ b/lib/simple_navigation/item.rb
@@ -61,12 +61,12 @@ module SimpleNavigation
     
     # Return string from options for insert before link.
     def html_before
-      html_before = options.fetch(:html_before)
+      html_before = options.fetch(:html_before) or ''
     end
   
     # Return string from options for insert after link.
     def html_after
-      html_after = options.fetch(:html_after)
+      html_after = options.fetch(:html_after) or ''
     end    
 
     # Returns the configured active_leaf_class if the item is the selected leaf,

--- a/lib/simple_navigation/item.rb
+++ b/lib/simple_navigation/item.rb
@@ -61,12 +61,12 @@ module SimpleNavigation
     
     # Return string from options for insert before link.
     def html_before
-      html_before = options.fetch(:html_before) or ''
+      options.fetch(:html_before, '')
     end
   
     # Return string from options for insert after link.
     def html_after
-      html_after = options.fetch(:html_after) or ''
+      options.fetch(:html_after, '')
     end    
 
     # Returns the configured active_leaf_class if the item is the selected leaf,

--- a/lib/simple_navigation/item.rb
+++ b/lib/simple_navigation/item.rb
@@ -58,6 +58,16 @@ module SimpleNavigation
 
       html_opts
     end
+    
+    # Return string from options for insert before link.
+    def html_before
+      html_before = options.fetch(:html_before)
+    end
+  
+    # Return string from options for insert after link.
+    def html_after
+      html_after = options.fetch(:html_after)
+    end    
 
     # Returns the configured active_leaf_class if the item is the selected leaf,
     # nil otherwise


### PR DESCRIPTION
From issue https://github.com/codeplant/simple-navigation/issues/132

Example (custom renderer):

``` ruby
class ContentListRenderer < SimpleNavigation::Renderer::List
  private

  def list_content(item_container)
    item_container.items.map { |item|
      li_options = item.html_options.except(:link)
      li_content = tag_for(item)
      li_content = item.content_before + li_content + item.content_after
      if include_sub_navigation?(item)
        li_content << render_sub_navigation_for(item)
      end
      content_tag(:li, li_content, li_options)
    }.join
  end
end
```

and in navigation (bootstrap list group):

``` ruby
SimpleNavigation::Configuration.run do |navigation|
  navigation.items do |m|
    m.dom_class = 'list-group'
    m.item :approval_list, 'List, '',
           html: { class: 'list-group-item' },
           content_after: "<span class=\"badge\">1234</span>".html_safe,
           link_html: {
             data: {
               push: true,
               target: '#messages .area-content'
             }
           }
  end
end
```
