### PR TITLE
make stack traces for errors in configs more usable

### DIFF
--- a/lib/simple_navigation/configuration.rb
+++ b/lib/simple_navigation/configuration.rb
@@ -23,7 +23,8 @@ module SimpleNavigation
     # Evals the config_file for the given navigation_context
     def self.eval_config(navigation_context = :default)
       context = SimpleNavigation.config_files[navigation_context]
-      SimpleNavigation.context_for_eval.instance_eval(context)
+      config_file_path = SimpleNavigation.config_file(navigation_context)
+      SimpleNavigation.context_for_eval.instance_eval(context, config_file_path)
     end
 
     # Starts processing the configuration


### PR DESCRIPTION
When there is an error in the navigation config, the stack trace won't
include a pointer to the actual config file and line but only something
like

```
(eval):5:in `block in eval_config'
```

This change supplies the path to the config file to `instance_eval` so
that the stack trace now include path and line where the error occurs.