### PR TITLE
Fix uninitialized variable `@dom_attributes` warning

### DIFF
--- a/lib/simple_navigation/item_container.rb
+++ b/lib/simple_navigation/item_container.rb
@@ -16,6 +16,7 @@ module SimpleNavigation
       @items ||= []
       @renderer = SimpleNavigation.config.renderer
       @auto_highlight = true
+      @dom_attributes = {}
     end
 
     def dom_attributes
@@ -24,7 +25,8 @@ module SimpleNavigation
         id: dom_id,
         class: dom_class
       }.reject { |_, v| v.nil? }
-      (@dom_attributes || {}).merge(dom_id_and_class)
+
+      @dom_attributes.merge(dom_id_and_class)
     end
 
     # Creates a new navigation item.


### PR DESCRIPTION
Background:
The line 
```ruby
(@dom_attributes || {}).merge(dom_id_and_class)
```` 
in `ItemContainer` 
printed warnings for usage of unitialized instance variable.

```
simple-navigation/lib/simple_navigation/item_container.rb:27: warning: instance variable @dom_attributes not initialized
```
This change will simply fix the issue and remove the warning

Changes:
- Initialize `@dom_attributes` in `initialize`