### PR TITLE
Delay rails6 initialization using on_load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 capybara-*
 gemfiles/*.lock
 log
+spec/fake_app/tmp

--- a/gemfiles/rails-6-0-stable.gemfile
+++ b/gemfiles/rails-6-0-stable.gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gem 'rake', '< 11.0'
+
+# not yet
+#gem 'railties', '~> 6.0.0'
+gem 'railties', '6.0.0.rc2'
+gem 'rspec-rails', '~> 3.8.2'
+
+gemspec path: '../'

--- a/lib/simple_navigation/adapters/rails.rb
+++ b/lib/simple_navigation/adapters/rails.rb
@@ -5,6 +5,21 @@ module SimpleNavigation
 
       def self.register
         SimpleNavigation.set_env(::Rails.root, ::Rails.env)
+
+        # Autoloading in initializers is deprecated on rails 6.0
+        # This delays the hook initialization using the on_load
+        # hooks, but does not change behaviour for existing
+        # rails versions.
+        if ::Rails::VERSION::MAJOR >= 6
+          ActiveSupport.on_load(:action_controller_base) do
+            SimpleNavigation::Adapters::Rails.register_controller_helpers
+          end
+        else
+          register_controller_helpers
+        end
+      end
+
+      def self.register_controller_helpers
         ActionController::Base.send(:include, SimpleNavigation::Helpers)
         SimpleNavigation::Helpers.instance_methods.each do |m|
           ActionController::Base.send(:helper_method, m.to_sym)


### PR DESCRIPTION
Autoloading within initilizers is deprecated in rails 6.0.

Adding helper method to ActionController::Base during initialization
will trigger autoloading it.

This delays adding the helper methods using an on_load() hook for
all rails version >= 6.