### PR TITLE
Run specs against rails 6 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ before_install:
 
 matrix:
   include:
+  - rvm: 2.5.8
+    gemfile: gemfiles/rails-6-1-stable.gemfile
+  - rvm: 2.6.7
+    gemfile: gemfiles/rails-6-1-stable.gemfile
+  - rvm: 2.7.3
+    gemfile: gemfiles/rails-6-1-stable.gemfile
   - rvm: 2.5.3
     gemfile: gemfiles/rails-6-0-stable.gemfile
   - rvm: 2.6.0
@@ -15,4 +21,3 @@ matrix:
     gemfile: gemfiles/rails-4-1-stable.gemfile
   - rvm: 2.3.3
     gemfile: gemfiles/rails-3-2-stable.gemfile
-  

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,7 @@ namespace :spec do
     rails-4-2-stable
     rails-5-2-stable
     rails-6-0-stable
+    rails-6-1-stable
   ]
 
   mappers.each do |gemfile|

--- a/gemfiles/rails-6-1-stable.gemfile
+++ b/gemfiles/rails-6-1-stable.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'rake', '< 11.0'
+
+# not yet
+gem 'railties', '~> 6.1.0'
+gem 'rspec-rails', '~> 3.8.2'
+
+gemspec path: '../'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,10 @@ end
 
 def setup_adapter_for(framework, context = double(:context))
   if framework == :rails
-    allow(context).to receive_messages(view_context: ActionView::Base.new)
+    # Rails 6.0 and 6.1 provide ActionView::Base.empty method that creates ActionView with an empty LookupContext.
+    # The method is not available on older versions
+    view_context = ActionView::Base.respond_to?(:empty) ? ActionView::Base.empty : ActionView::Base.new
+    allow(context).to receive_messages(view_context: view_context)
   end
 
   allow(SimpleNavigation).to receive_messages(framework: framework)


### PR DESCRIPTION
Rails 6.1 removes default values from `ActionView::Base` initializer ([see here](https://github.com/rails/rails/blob/v6.1.3.2/actionview/lib/action_view/base.rb#L230)).

Rails 6.0 introduces `ActionView::Base.empty` method which initialize the instance with `ActionView::LookupContext.new([])` as lookup_context. That's exactly the same behaviour as `ActionView::Base.new` (see [here](https://github.com/rails/rails/blob/v6.0.3.7/actionview/lib/action_view/base.rb#L258) and [here](https://github.com/rails/rails/blob/v6.0.3.7/actionview/lib/action_view/base.rb#L219)).

That's why I use `ActionView::Base.empty` when it's available and keep `ActionView::Base.new` when it's not.