### PR TITLE
remove "Using the raise_error matcher without providing a specific error or message risks false positives" warning from specs

### DIFF
--- a/spec/simple_navigation/adapters/rails_spec.rb
+++ b/spec/simple_navigation/adapters/rails_spec.rb
@@ -186,7 +186,7 @@ module SimpleNavigation
             before { adapter.instance_variable_set(:@template, nil) }
 
             it 'raises an exception' do
-              expect{ adapter.context_for_eval }.to raise_error
+              expect{ adapter.context_for_eval }.to raise_error(RuntimeError, 'no context set for evaluation the config file')
             end
           end
         end

--- a/spec/simple_navigation/adapters/sinatra_spec.rb
+++ b/spec/simple_navigation/adapters/sinatra_spec.rb
@@ -9,7 +9,7 @@ describe SimpleNavigation::Adapters::Sinatra do
     context "when adapter's context is not set" do
       it 'raises an exception' do
         allow(adapter).to receive_messages(context: nil)
-        expect{ adapter.context_for_eval }.to raise_error
+        expect{ adapter.context_for_eval }.to raise_error(RuntimeError, 'no context set for evaluation the config file')
       end
     end
 

--- a/spec/simple_navigation/config_file_finder_spec.rb
+++ b/spec/simple_navigation/config_file_finder_spec.rb
@@ -23,7 +23,7 @@ module SimpleNavigation
 
         context 'and no navigation.rb file is found in the paths' do
           it 'raises an exception' do
-            expect{ finder.find(context) }.to raise_error
+            expect { finder.find(context) }.to raise_error(RuntimeError, /Config file 'navigation.rb' not found in path\(s\)/)
           end
         end
       end
@@ -41,7 +41,7 @@ module SimpleNavigation
 
         context 'and no other_navigation.rb file is found in the paths' do
           it 'raise an exception' do
-            expect{ finder.find(context) }.to raise_error
+            expect{ finder.find(context) }.to raise_error(RuntimeError, /Config file 'other_navigation.rb' not found in path\(s\)/)
           end
         end
       end

--- a/spec/simple_navigation/configuration_spec.rb
+++ b/spec/simple_navigation/configuration_spec.rb
@@ -89,7 +89,7 @@ module SimpleNavigation
           let(:provider) { double(:provider) }
 
           it 'raises an exception' do
-            expect{ config.items(provider) {} }.to raise_error
+            expect{ config.items(provider) {} }.to raise_error(RuntimeError, 'please specify either items_provider or block, but not both')
           end
         end
 
@@ -139,7 +139,7 @@ module SimpleNavigation
 
         context 'when items_provider is not specified' do
           it "raises an exception" do
-            expect{ config.items }.to raise_error
+            expect{ config.items }.to raise_error(RuntimeError, 'please specify either items_provider or block, but not both')
           end
         end
       end

--- a/spec/simple_navigation/helpers_spec.rb
+++ b/spec/simple_navigation/helpers_spec.rb
@@ -382,7 +382,7 @@ module SimpleNavigation
           it 'raises an exception' do
             expect{
               controller.render_navigation(level: :invalid)
-            }.to raise_error
+            }.to raise_error(ArgumentError, 'Invalid navigation level: invalid')
           end
         end
       end
@@ -408,7 +408,7 @@ module SimpleNavigation
         before { allow(SimpleNavigation).to receive_messages(primary_navigation: nil) }
 
         it 'raises an exception' do
-          expect{controller.render_navigation}.to raise_error
+          expect{controller.render_navigation}.to raise_error(RuntimeError, 'no primary navigation defined, either use a navigation config file or pass items directly to render_navigation')
         end
       end
 

--- a/spec/simple_navigation/item_container_spec.rb
+++ b/spec/simple_navigation/item_container_spec.rb
@@ -435,7 +435,7 @@ module SimpleNavigation
             it 'raises an error' do
               expect{
                 item_container.item('key', 'name', 'url', { if: 'text' })
-              }.to raise_error
+              }.to raise_error(ArgumentError, ':if or :unless must be procs or lambdas')
             end
           end
         end

--- a/spec/simple_navigation/item_spec.rb
+++ b/spec/simple_navigation/item_spec.rb
@@ -346,7 +346,7 @@ module SimpleNavigation
           let(:options) {{ highlights_on: :hello }}
 
           it 'raises an exception' do
-            expect{ item.selected? }.to raise_error
+            expect{ item.selected? }.to raise_error(ArgumentError, ':highlights_on must be a Regexp, Proc or :subpath')
           end
         end
       end

--- a/spec/simple_navigation/items_provider_spec.rb
+++ b/spec/simple_navigation/items_provider_spec.rb
@@ -36,7 +36,7 @@ module SimpleNavigation
         let(:provider) { double(:provider) }
 
         it 'raises an exception' do
-          expect{ items_provider.items }.to raise_error
+          expect{ items_provider.items }.to raise_error(RuntimeError, /items_provider either must be a symbol .*, an object .* or an enumerable/)
         end
       end
     end

--- a/spec/simple_navigation/renderer/base_spec.rb
+++ b/spec/simple_navigation/renderer/base_spec.rb
@@ -32,7 +32,7 @@ module SimpleNavigation
 
       describe '#render' do
         it "raise an exception to indicate it's a subclass responsibility" do
-          expect{ base.render(:container) }.to raise_error
+          expect{ base.render(:container) }.to raise_error(NotImplementedError, 'subclass responsibility')
         end
       end
 

--- a/spec/simple_navigation_spec.rb
+++ b/spec/simple_navigation_spec.rb
@@ -104,7 +104,7 @@ describe SimpleNavigation do
 
     context "when the config file for the context doesn't exists" do
       it 'raises an exception' do
-        expect{ subject.load_config }.to raise_error
+        expect{ subject.load_config }.to raise_error(RuntimeError, /Config file 'navigation.rb' not found in path\(s\)/)
       end
     end
   end
@@ -152,7 +152,7 @@ describe SimpleNavigation do
       it 'raises an exception' do
         expect{
           subject.active_item_container_for('something else')
-        }.to raise_error
+        }.to raise_error(ArgumentError, 'Invalid navigation level: something else')
       end
     end
   end


### PR DESCRIPTION
This PR removes the following warning
```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, 
since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, 
potentially allowing the expectation to pass without even executing the method you are intending to call. 
```
by adding the Error class and the expected message. When the message is long, I used a regexp.